### PR TITLE
ui: don't use loading component for no results text

### DIFF
--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -219,6 +219,23 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
     this.props.setShow(selected.value);
   }
 
+  renderTable(jobs: Job[]) {
+    if (_.isEmpty(jobs)) {
+      return <h2 className="no-results">No Results</h2>;
+    }
+
+    return (
+      <JobsSortedTable
+        data={jobs}
+        sortSetting={this.props.sort}
+        onChangeSortSetting={this.props.setSort}
+        className="jobs-table"
+        rowClass={job => "jobs-table__row--" + job.status}
+        columns={jobsTableColumns}
+      />
+    );
+  }
+
   render() {
     const data = this.props.jobs && this.props.jobs.length > 0 && this.props.jobs;
     return <div className="jobs-page">
@@ -251,18 +268,9 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
         </PageConfig>
       </div>
       <Loading loading={_.isNil(this.props.jobs)} className="loading-image loading-image__spinner" image={spinner}>
-        <Loading loading={_.isEmpty(data)} className="loading-image loading-image__text" text="No Results">
-          <section className="section">
-            <JobsSortedTable
-              data={data}
-              sortSetting={this.props.sort}
-              onChangeSortSetting={this.props.setSort}
-              className="jobs-table"
-              rowClass={job => "jobs-table__row--" + job.status}
-              columns={jobsTableColumns}
-            />
-          </section>
-        </Loading>
+        <section className="section">
+          { renderTable(data) }
+        </section>
       </Loading>
     </div>;
   }

--- a/pkg/ui/src/views/jobs/jobs.styl
+++ b/pkg/ui/src/views/jobs/jobs.styl
@@ -1,0 +1,4 @@
+.no-results
+  display flex
+  align-items center
+  justify-content center

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -179,8 +179,3 @@ div.raft-filters
     background-size 40px 40px
     min-height 40px
     width 400px
-
-  &__text
-    display flex
-    align-items center
-    justify-content center


### PR DESCRIPTION
Previously the Loading component was being abused for simple conditional
rendering.  This replaces that with a more direct conditional render.

Release note: None